### PR TITLE
Add AGENTS.md with Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is **not** a web app or service — it is a collection of standalone desktop tools (PowerShell, Bash, Python) that binary-patch Discord's native `discord_voice.node` module. There are no servers, databases, Docker containers, or package managers (`package.json` files in the repo are Discord module metadata, not project deps).
+
+### Key tools and how to exercise them
+
+| Tool | Path | Run |
+|---|---|---|
+| **Offset Finder CLI** | `Updates/Offset Finder/discord_voice_node_offset_finder_v5.py` | `python3 <path> <discord_voice.node>` (needs a real binary; exits cleanly with an error if none provided) |
+| **Offset Finder GUI** | `Updates/Offset Finder/offset_finder_gui.py` | `python3 <path>` (requires display / tkinter) |
+| **Linux Patcher** | `Updates/Linux/Updates/discord_voice_patcher_linux.sh` | `bash <path> --help` (requires Discord installed to actually patch) |
+| **Linux Launcher** | `Updates/Linux/discord-stereo-launcher.sh` | `bash <path> --help` |
+| **Linux Installer GUI** | `Updates/Linux/Updates/Discord_Stereo_Installer_For_Linux.py` | `python3 <path>` (requires display / tkinter + bash scripts alongside) |
+
+### Linting
+
+- **Shell scripts:** `shellcheck Updates/Linux/Updates/discord_voice_patcher_linux.sh` and `shellcheck Updates/Linux/discord-stereo-launcher.sh`. Existing warnings are informational (SC2034, SC2015, SC2012, SC2155) — not errors.
+- **Python scripts:** `python3 -m py_compile <path>` for syntax checking. All three `.py` files compile cleanly.
+
+### Build / compile verification
+
+The patcher compiles C++ at runtime. To verify the toolchain works:
+```bash
+g++ -O2 -std=c++17 -c <amplifier.cpp> -o /dev/null
+```
+Both `g++` and `clang++` are available in the environment.
+
+### Required system packages
+
+- `python3`, `python3-tk` (for GUI tools), `shellcheck` (for linting)
+- `g++` or `clang++` (for the patcher's runtime C++ compilation)
+- `networkx`, `matplotlib` (optional Python packages for offset finder visualization)
+
+### Important caveats
+
+- The tools **cannot run end-to-end** without a Discord desktop client installed and a real `discord_voice.node` binary present. The `--help` and syntax-check paths are the appropriate "hello world" for this codebase in a headless cloud VM.
+- The `Voice Node Dump/` directory contains archived module trees for research — these are metadata files, not the actual `.node` binaries (those are too large for git).
+- Windows scripts (`.ps1`, `.bat`) are not testable on Linux.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with development environment instructions for Cursor Cloud agents.

This file documents:
- The codebase structure (standalone desktop tools, not a web service)
- How to exercise each tool (offset finder, patcher, launcher, installer GUI)
- Linting commands (`shellcheck`, `python3 -m py_compile`)
- C++ toolchain verification
- Required system packages and Python dependencies
- Important caveats (no end-to-end testing without Discord installed)

## Verification

All tools verified working in the cloud VM:

[dev_env_verification.log](https://cursor.com/agents/bc-f347f940-c58b-4bbf-bfac-771ca3bc8570/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdev_env_verification.log)

- Python 3.12.3, Bash 5.2.21, g++ 13.3.0, clang++ 18.1.3, shellcheck 0.9.0
- All 3 Python scripts pass syntax checks
- Both shell scripts pass shellcheck (warnings only, no errors)  
- C++ amplifier source compiles successfully
- All CLI tools execute correctly (`--help` paths)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f347f940-c58b-4bbf-bfac-771ca3bc8570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f347f940-c58b-4bbf-bfac-771ca3bc8570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

