### PR TITLE
Fix MonoDownmixer crash on Linux: dynamic JMP target for Clang instruction layouts

### DIFF
--- a/Updates/Linux/Updates/discord_voice_patcher_linux.sh
+++ b/Updates/Linux/Updates/discord_voice_patcher_linux.sh
@@ -1123,7 +1123,9 @@ private:
 
         const unsigned char orig_mono2[]  = {0x84, 0xC0};
         const unsigned char patch_mono2[] = {0x90, 0x90};
-        bool o13 = OrigOrAlt(Offsets::MonoDownmixer, orig_mono2, 2, patch_mono2, 2);
+        const unsigned char patch_mono_jmp[] = {0xE9};
+        bool o13 = OrigOrAlt(Offsets::MonoDownmixer, orig_mono2, 2, patch_mono2, 2)
+                || CheckBytes(Offsets::MonoDownmixer, patch_mono_jmp, 1);
 
         const unsigned char orig_throw1[] = {0x41};
         const unsigned char patch_throw[] = {0xC3};
@@ -1204,7 +1206,57 @@ private:
         patchCount++;
         if (!PatchBytes(Offsets::AudioEncoderOpusConfigSetChannels, "\x02", 1)) return false;
         patchCount++;
-        if (!PatchBytes(Offsets::MonoDownmixer, "\x90\x90\x90\x90\x90\x90\x90\x90\x90\x90\x90\x90\xE9", 13)) return false;
+        // MonoDownmixer: NOP the test+jz+cmp, then convert jg to JMP.
+        // Layout varies between MSVC (7-byte cmp dword [rsi+disp32]) and
+        // Clang (4-byte cmp dword [rbx+disp8]).  Detect the jg opcode
+        // dynamically so the NOP sled length is always correct.
+        {
+            uint32_t fo = Offsets::MonoDownmixer - Offsets::FILE_OFFSET_ADJUSTMENT;
+            unsigned char* p = (unsigned char*)fileData + fo;
+            // p[0..1] = test al,al (84 C0)
+            // p[2..3] = jz rel8   (74 xx)
+            // p[4]    = cmp opcode (83)
+            if (p[4] != 0x83) {
+                printf("ERROR: MonoDownmixer: expected cmp (0x83) at +4, got 0x%02X\n", p[4]);
+                return false;
+            }
+            int cmp_mod = p[5] >> 6;
+            int cmp_len;  // total bytes of the cmp instruction
+            if (cmp_mod == 1)      cmp_len = 4;  // cmp [reg+disp8], imm8
+            else if (cmp_mod == 2) cmp_len = 7;  // cmp [reg+disp32], imm8
+            else {
+                printf("ERROR: MonoDownmixer: unexpected cmp mod=%d\n", cmp_mod);
+                return false;
+            }
+            int jg_off = 4 + cmp_len;  // offset of jg from p
+            unsigned char jg0 = p[jg_off];
+            int32_t jmp_target_abs;  // absolute offset from p of the jg target
+            if (jg0 == 0x0F && (p[jg_off+1] == 0x8F || p[jg_off+1] == 0x8D)) {
+                // near jg/jge: 6-byte insn (0F 8F/8D + rel32)
+                int32_t rel32;
+                memcpy(&rel32, p + jg_off + 2, 4);
+                jmp_target_abs = jg_off + 6 + rel32;
+            } else if (jg0 == 0x7F || jg0 == 0x7D) {
+                // short jg/jge: 2-byte insn (7F/7D + rel8)
+                int8_t rel8 = (int8_t)p[jg_off + 1];
+                jmp_target_abs = jg_off + 2 + rel8;
+            } else {
+                printf("ERROR: MonoDownmixer: expected jg (0F 8F / 7F) at +%d, got 0x%02X\n", jg_off, jg0);
+                return false;
+            }
+            // NOP everything from p[0] to where we place our JMP
+            // We place a 5-byte JMP (E9 + rel32) such that it jumps to the
+            // same target as the original jg.
+            // Place JMP at offset 0 after NOPping the block.
+            int total_orig_len = (jg0 == 0x0F) ? (jg_off + 6) : (jg_off + 2);
+            // NOP the entire block first
+            memset(p, 0x90, total_orig_len);
+            // Write JMP rel32 at the start: E9 <rel32>
+            // JMP target relative to (p + 5): rel32 = jmp_target_abs - 5
+            int32_t jmp_rel32 = jmp_target_abs - 5;
+            p[0] = 0xE9;
+            memcpy(p + 1, &jmp_rel32, 4);
+        }
         patchCount++;
 
         printf("  [2/5] Setting bitrate to %dkbps...\n", BITRATE);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root Cause

The Linux patcher crashes Discord after patching because the **MonoDownmixer** patch writes incorrect machine code for Clang-compiled ELF binaries.

The hardcoded 13-byte patch (`90×12 + E9`) was designed for MSVC's instruction layout where `cmp [rsi+disp32], 9` is 7 bytes long. On Linux, Clang emits `cmp [rbx+disp8], 9` which is only **4 bytes**, so the `E9` (JMP) opcode lands 3 bytes too late — it reads bytes from the **next instruction** as its displacement, producing a garbage jump target that crashes Discord.

### MSVC layout (Windows) — works correctly
```
+0:  84 C0                    test al, al        (2 bytes)
+2:  74 0D                    jz +13             (2 bytes)
+4:  83 BE xx xx 00 00 09     cmp [rsi+disp32],9 (7 bytes)
+11: 0F 8F yy yy yy yy       jg near            (6 bytes)
                                                  total: 17 bytes
Patch: E9 at +12 replaces 8F, inherits rel32 → correct target
```

### Clang layout (Linux) — crashes
```
+0:  84 C0                    test al, al        (2 bytes)
+2:  74 0A                    jz +10             (2 bytes)
+4:  83 7B xx 09              cmp [rbx+disp8],9  (4 bytes, NOT 7!)
+8:  0F 8F yy yy yy yy       jg near            (6 bytes)
                                                  total: 14 bytes
Patch: NOPs destroy the jg displacement, E9 at +12 reads garbage → CRASH
```

## Fix

Replace the hardcoded 13-byte patch with dynamic logic that:

1. Inspects the `cmp` instruction's ModR/M byte to determine if it uses disp8 (4 bytes) or disp32 (7 bytes)
2. Locates the `jg` instruction (near `0F 8F` or short `7F`/`7D`)
3. Reads the original jump displacement
4. NOPs the entire test+jz+cmp+jg block
5. Writes a proper 5-byte `JMP rel32` at offset 0 with the correct computed displacement

This handles all three observed instruction layouts:
- **MSVC**: `cmp [rsi+disp32]` + near `jg` (`0F 8F`) → 17 bytes
- **Clang**: `cmp [rbx+disp8]` + near `jg` (`0F 8F`) → 14 bytes
- **Clang**: `cmp [rbx+disp8]` + short `jg` (`7F`) → 10 bytes

Also updates pre-patch validation to accept already-patched binaries where MonoDownmixer starts with `E9` (JMP).

## Testing

- Verified all three instruction layout variants produce correct JMP targets using a standalone C++ test harness
- Shellcheck passes (same informational warnings as before, no new issues)
- Generated C++ source compiles cleanly with g++ -O2 -std=c++17
- Patcher `--help` executes correctly

Note: full end-to-end testing requires a Discord installation with the matching `discord_voice.node` binary, which is not available in the CI environment.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f347f940-c58b-4bbf-bfac-771ca3bc8570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f347f940-c58b-4bbf-bfac-771ca3bc8570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

