### PR TITLE
Fix Windows patcher hanging on unrelated Update.exe after Discord closes

### DIFF
--- a/Updates/Windows/Discord_voice_node_patcher.ps1
+++ b/Updates/Windows/Discord_voice_node_patcher.ps1
@@ -733,6 +733,39 @@ function Get-InstalledClients {
 
 # region Process Management
 
+function Get-DiscordInstallBasePaths {
+    <#
+        Base folders that contain Discord's Update.exe (e.g. %LocalAppData%\Discord).
+        Used so we only touch Update.exe from known Discord installs — the process name
+        "Update" alone matches many unrelated Windows updaters and caused long waits
+        after Discord had already exited.
+    #>
+    $bases = New-Object 'System.Collections.Generic.HashSet[string]'
+    foreach ($k in $Script:DiscordClients.Keys) {
+        $c = $Script:DiscordClients[$k]
+        foreach ($prop in @('Path', 'FallbackPath')) {
+            if (-not $c.ContainsKey($prop)) { continue }
+            $dir = $c[$prop]
+            if ([string]::IsNullOrWhiteSpace($dir) -or -not (Test-Path -LiteralPath $dir)) { continue }
+            try {
+                $full = (Get-Item -LiteralPath $dir).FullName.TrimEnd('\')
+                if ($full) { [void]$bases.Add($full) }
+            } catch { }
+        }
+    }
+    return @($bases)
+}
+
+function Stop-DiscordUpdateProcesses {
+    $paths = Get-DiscordInstallBasePaths
+    if (-not $paths -or $paths.Count -eq 0) { return $true }
+    $ok = $true
+    foreach ($base in $paths) {
+        if (-not (Stop-DiscordProcesses -ProcessNames @('Update') -InstallPath $base)) { $ok = $false }
+    }
+    return $ok
+}
+
 function Stop-DiscordProcesses {
     param([string[]]$ProcessNames, [string]$InstallPath)
     if (-not $ProcessNames -or $ProcessNames.Count -eq 0) { return $true }
@@ -782,8 +815,10 @@ function Stop-DiscordProcesses {
 }
 
 function Stop-AllDiscordProcesses {
-    $allProcs = @("Discord","DiscordCanary","DiscordPTB","DiscordDevelopment","Lightcord","BetterVencord","Equicord","Vencord","Update")
-    return Stop-DiscordProcesses $allProcs
+    $allProcs = @("Discord","DiscordCanary","DiscordPTB","DiscordDevelopment","Lightcord","BetterVencord","Equicord","Vencord")
+    $main = Stop-DiscordProcesses $allProcs
+    $upd = Stop-DiscordUpdateProcesses
+    return ($main -and $upd)
 }
 
 # endregion Process Management


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`Stop-AllDiscordProcesses` included the process name `Update` alongside Discord client names. On Windows, `Get-Process -Name Update` matches **every** process whose executable base name is `Update.exe`, not only Discord's updater.

After Discord itself was killed, unrelated `Update.exe` processes (other apps' updaters) could still be running. The stop/wait loop in `Stop-DiscordProcesses` would keep seeing those processes and sleep up to ~5 seconds per full iteration (20 × 250 ms), so the patcher appeared stuck "closing Discord" even though Discord was already gone.

## Fix

- Removed the bare `Update` name from the global kill list.
- Added `Get-DiscordInstallBasePaths` to collect known Discord install roots from `DiscordClients` (`Path` / `FallbackPath`).
- Added `Stop-DiscordUpdateProcesses`, which stops `Update.exe` only when its path is under one of those folders (reusing the existing `InstallPath` filtering in `Stop-DiscordProcesses`).

GUI single-client mode already scoped `Update` via `-InstallPath`; this aligns "close all" / restore with that behavior.

## Verification

- Logic review: unrelated `Update.exe` instances are no longer considered when waiting for Discord-related processes to exit.
- No automated tests in repo; PowerShell parser not available in this Linux CI environment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4e7884b-9522-4e1b-8407-6cf46e244bec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4e7884b-9522-4e1b-8407-6cf46e244bec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

