### PR TITLE
Use Discord App Build in offset metadata instead of file size

### DIFF
--- a/Updates/Offset Finder/discord_voice_node_offset_finder_v5.py
+++ b/Updates/Offset Finder/discord_voice_node_offset_finder_v5.py
@@ -3914,6 +3914,17 @@ def _infer_discord_app_version_from_path(file_path):
     return m.group(1).strip() if m else "unspecified"
 
 
+def _infer_discord_app_build_from_path(file_path):
+    """Windows desktop build id (e.g. 1.0.9234) from app folder or `windows!app- x.y` dump paths."""
+    if not file_path:
+        return "unspecified"
+    s = os.path.normpath(str(file_path))
+    m = re.search(r'windows!app-\s*([\d.]+)', s, re.I)
+    if m:
+        return m.group(1).strip()
+    return _infer_discord_app_version_from_path(file_path)
+
+
 def format_windows_patcher_block(results, bin_info, file_path, file_size):
     """Windows patcher copy block; order = $Script:RequiredOffsetNames."""
     if not bin_info or not file_path or file_size is None:
@@ -3926,6 +3937,7 @@ def format_windows_patcher_block(results, bin_info, file_path, file_size):
     with open(file_path, 'rb') as f:
         md5 = hashlib.md5(f.read()).hexdigest().lower()
     app_ver = _infer_discord_app_version_from_path(file_path)
+    app_build = _infer_discord_app_build_from_path(file_path)
     lines = [
         "# region Offsets (PASTE HERE)",
         "# Paste output from: python discord_voice_node_offset_finder_v5.py <path\\to\\discord_voice.node>",
@@ -3934,8 +3946,8 @@ def format_windows_patcher_block(results, bin_info, file_path, file_size):
         "$Script:OffsetsMeta = @{",
         '    FinderVersion = "discord_voice_node_offset_finder.py v%s"' % VERSION,
         '    DiscordAppVersion = "%s"' % app_ver,
-        "    Size          = %s" % file_size,
-        '    MD5           = "%s"' % md5,
+        '    DiscordAppBuild     = "%s"' % app_build,
+        '    MD5                 = "%s"' % md5,
         "}",
         "",
         "$Script:Offsets = @{",

--- a/Updates/Offset Finder/offset_finder_gui.py
+++ b/Updates/Offset Finder/offset_finder_gui.py
@@ -2,6 +2,7 @@
 """Tk GUI for discord_voice_node_offset_finder_v5.py (copy blocks for Windows/Linux/macOS)."""
 
 import os
+import re
 import sys
 import shutil
 import atexit
@@ -428,7 +429,21 @@ class OffsetFinderGUI:
         fsize = os.path.getsize(path)
         fname = os.path.basename(path)
         self._append_output(f"  File: {fname}\n", "header")
-        self._append_output(f"  Size: {fsize:,} bytes | OS: {self.os_var.get()}\n", "info")
+        is_pe = False
+        with open(path, "rb") as f:
+            is_pe = f.read(2) == b"MZ"
+        if is_pe:
+            m = re.search(r"windows!app-\s*([\d.]+)", path, re.I) or re.search(
+                r"app-\s*([\d.]+)", path, re.I
+            )
+            build = m.group(1).strip() if m else "unspecified"
+            self._append_output(
+                f"  Discord App Build: {build} | OS: {self.os_var.get()}\n", "info"
+            )
+        else:
+            self._append_output(
+                f"  Size: {fsize:,} bytes | OS: {self.os_var.get()}\n", "info"
+            )
         self._append_output(f"  {'-' * 55}\n\n", "info")
 
         thread = threading.Thread(target=self._run_finder_thread, args=(path,), daemon=True)
@@ -614,7 +629,7 @@ class OffsetFinderGUI:
                 self._append_output_safe("  Cross-validation: clean\n" if not xval else f"  Cross-validation: {len(xval)} issue(s)\n", "pass" if not xval else "warn")
 
             if fmt == "pe" and hasattr(mod, "format_windows_patcher_block"):
-                # Finder v5.1.4+: Windows copy block includes DiscordAppVersion (from app-x.y.z in path); ELF still 17 + MultiChannel Opus when present
+                # Windows copy block: OffsetsMeta includes DiscordAppBuild (from app path) and MD5; ELF still 17 + MultiChannel Opus when present
                 block = mod.format_windows_patcher_block(results, bin_info, path, file_size)
                 if block:
                     self.last_windows_block = _ascii_safe(block)

--- a/Updates/Windows/Discord_voice_node_patcher.ps1
+++ b/Updates/Windows/Discord_voice_node_patcher.ps1
@@ -33,8 +33,8 @@ $Script:SCRIPT_VERSION = "8"
 $Script:OffsetsMeta = @{
     FinderVersion = "discord_voice_node_offset_finder.py v5.1.3"
     DiscordAppVersion = "unspecified"
-    Size          = 14411192
-    MD5           = "e4bdf195be0190f210786483cb9373fb"
+    DiscordAppBuild   = "1.0.9234"
+    MD5               = "e4bdf195be0190f210786483cb9373fb"
 }
 
 $Script:Offsets = @{
@@ -523,19 +523,32 @@ function Clear-DirectoryContentsSafe {
     }
 }
 
+function Get-EmbeddedOffsetsTargetAppId {
+    param($Meta)
+    if (-not $Meta) { return $null }
+    $b = $Meta.DiscordAppBuild
+    if ($b -and [string]$b -ne 'unspecified') { return [string]$b }
+    $s = $Meta.DiscordAppVersion
+    if ($s -and [string]$s -ne 'unspecified') { return [string]$s }
+    $legacy = $Meta.Build
+    if ($legacy) { return [string]$legacy }
+    return $null
+}
+
 function Get-OffsetsCopyBlock {
     $meta = $Script:OffsetsMeta
     $offs = $Script:Offsets
     if (-not $meta -or -not $offs) { throw "Offsets not loaded" }
     $offsetOrder = $Script:RequiredOffsetNames
     $maxLen = ($offsetOrder | ForEach-Object { $_.Length } | Measure-Object -Maximum).Maximum
+    $dab = if ($null -ne $meta.DiscordAppBuild) { $meta.DiscordAppBuild } else { 'unspecified' } # legacy: key absent until re-paste from offset finder
     $lines = @(
         "# region Offsets (PASTE HERE)",
         "",
         "`$Script:OffsetsMeta = @{",
         "    FinderVersion     = `"$($meta.FinderVersion)`"",
         "    DiscordAppVersion = `"$($meta.DiscordAppVersion)`"",
-        "    Size              = $($meta.Size)",
+        "    DiscordAppBuild   = `"$dab`"",
         "    MD5               = `"$($meta.MD5)`"",
         "}",
         "",
@@ -2838,9 +2851,8 @@ function Get-PreparedVoiceBackupPath {
 
         $meta = $Script:Config.OffsetsMeta
         if ($meta) {
-            $tver = $meta.DiscordAppVersion
-            if (-not $tver -and $meta.Build) { $tver = $meta.Build }
-            if ($tver) { Write-Log "Embedded offsets target Discord app: $tver" -Level Info }
+            $tver = Get-EmbeddedOffsetsTargetAppId -Meta $meta
+            if ($tver) { Write-Log "Embedded offsets target Discord app build: $tver" -Level Info }
             if ($meta.MD5) {
                 $expected = ($meta.MD5.ToString()).ToLowerInvariant()
                 if ($nodeMd5 -ne $expected) {
@@ -2853,11 +2865,11 @@ function Get-PreparedVoiceBackupPath {
             } else {
                 Write-Log "OffsetsMeta.MD5 is not set - skipping voice node hash check." -Level Warning
             }
-            if ($meta.Size) {
+            if ($null -ne $meta.Size) {
                 try {
                     $expectedSize = [int64]$meta.Size
                     if ($expectedSize -ne $nodeSize) {
-                        Write-Log "Warning: OffsetsMeta.Size ($expectedSize) does not match downloaded node size ($nodeSize)" -Level Warning
+                        Write-Log "Warning: OffsetsMeta.Size (legacy) ($expectedSize) does not match downloaded node size ($nodeSize)" -Level Warning
                     }
                 } catch { }
             }
@@ -2906,9 +2918,7 @@ function Invoke-PatchClients {
 
             $version = Get-DiscordAppVersion $appPath
             Write-Log "Discord app version: $version" -Level Info
-            $targetVer = $null
-            if ($Script:Config.OffsetsMeta) { $targetVer = $Script:Config.OffsetsMeta.DiscordAppVersion }
-            if (-not $targetVer -and $Script:Config.OffsetsMeta.Build) { $targetVer = $Script:Config.OffsetsMeta.Build }
+            $targetVer = if ($Script:Config.OffsetsMeta) { Get-EmbeddedOffsetsTargetAppId -Meta $Script:Config.OffsetsMeta } else { $null }
             if ($targetVer -and $version -ne 'Unknown' -and $version -ne $targetVer) {
                 Write-Log "Installed app ($version) differs from embedded offset target ($targetVer); if patching fails, refresh offsets for your build." -Level Warning
             }

--- a/Updates/Windows/Discord_voice_node_patcher.ps1
+++ b/Updates/Windows/Discord_voice_node_patcher.ps1
@@ -542,14 +542,17 @@ function Get-OffsetsCopyBlock {
     $offsetOrder = $Script:RequiredOffsetNames
     $maxLen = ($offsetOrder | ForEach-Object { $_.Length } | Measure-Object -Maximum).Maximum
     $dab = if ($null -ne $meta.DiscordAppBuild) { $meta.DiscordAppBuild } else { 'unspecified' } # legacy: key absent until re-paste from offset finder
+    $md5 = if ($meta.MD5) { ($meta.MD5.ToString()).ToLowerInvariant() } else { '' }
     $lines = @(
         "# region Offsets (PASTE HERE)",
+        '# Paste output from: python discord_voice_node_offset_finder_v5.py <path\to\discord_voice.node>',
+        "# Required: core 17 + extended Windows offsets (RVA hex). Copy the full block into Discord_voice_node_patcher.ps1.",
         "",
         "`$Script:OffsetsMeta = @{",
-        "    FinderVersion     = `"$($meta.FinderVersion)`"",
+        "    FinderVersion = `"$($meta.FinderVersion)`"",
         "    DiscordAppVersion = `"$($meta.DiscordAppVersion)`"",
-        "    DiscordAppBuild   = `"$dab`"",
-        "    MD5               = `"$($meta.MD5)`"",
+        "    DiscordAppBuild     = `"$dab`"",
+        "    MD5                 = `"$md5`"",
         "}",
         "",
         "`$Script:Offsets = @{"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Windows offset copy blocks and the patcher `OffsetsMeta` now record **Discord App Build** (from the `app-x.y.z` or `windows!app-` path) instead of the `discord_voice.node` file byte size. MD5 remains the primary binary fingerprint.

## Follow-up: Copy Offsets in tandem
`Get-OffsetsCopyBlock` now matches `format_windows_patcher_block` from the offset finder: same two header comment lines, same `OffsetsMeta` key spacing, and **lowercase MD5** in the copied text so a round-trip through “Copy Offsets” matches a fresh finder run.

## Changes
- **Offset finder** (`format_windows_patcher_block`): outputs `DiscordAppBuild` with `FinderVersion`, `DiscordAppVersion`, and `MD5` (no `Size`). Added path parsing for `windows!app-` style paths.
- **GUI**: for PE (Windows) files, the header line shows `Discord App Build: …` instead of `Size: …` bytes; non-PE still shows file size.
- **Discord_voice_node_patcher.ps1**: default embedded `OffsetsMeta` includes `DiscordAppBuild`; `Get-OffsetsCopyBlock` and `Get-EmbeddedOffsetsTargetAppId` keep Copy Offsets and “installed vs target” checks aligned. Legacy `OffsetsMeta.Size` still issues an optional warning if an old block is pasted.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ffa4372-91f1-4859-aca2-18508318c304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ffa4372-91f1-4859-aca2-18508318c304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

