### PR TITLE
Windows patcher: silence gain above 3x

### DIFF
--- a/Updates/Windows/Discord_voice_node_patcher.ps1
+++ b/Updates/Windows/Discord_voice_node_patcher.ps1
@@ -1747,6 +1747,30 @@ function Remove-PatcherTempFiles {
 
 function Get-AmplifierSourceCode {
     $gain = [int]$Script:Config.AudioGainMultiplier
+    if ($gain -gt 3) {
+        return @"
+typedef signed char        int8_t;
+typedef short              int16_t;
+typedef int                int32_t;
+typedef long long          int64_t;
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+
+extern "C" void __cdecl hp_cutoff(const float* in, int cutoff_Hz, float* out, int* hp_mem, int len, int channels, int Fs, int arch)
+{
+    (void)in; (void)cutoff_Hz; (void)hp_mem; (void)Fs; (void)arch;
+    for (unsigned long i = 0; i < channels * len; i++) out[i] = 0.0f;
+}
+
+extern "C" void __cdecl dc_reject(const float* in, float* out, int* hp_mem, int len, int channels, int Fs)
+{
+    (void)in; (void)hp_mem; (void)Fs;
+    for (int i = 0; i < channels * len; i++) out[i] = 0.0f;
+}
+"@
+    }
     if ($gain -ge 3) {
         Write-Log "Generating amplifier: 3x+ ONLY -> Multiplier = $($gain - 2) (GUI $gain x)" -Level Info
         $multiplier = $gain - 2
@@ -2666,7 +2690,9 @@ function New-SourceFiles {
         [System.IO.File]::WriteAllText($amp, $ampCode, [System.Text.Encoding]::ASCII)
         $ampContent = Get-Content $amp -Raw
         $cfgGain = [int]$Script:Config.AudioGainMultiplier
-        if ($cfgGain -ge 3) {
+        if ($cfgGain -gt 3) {
+            if ($ampContent -match '#define (GAIN_MULTIPLIER|Multiplier)\b') { Write-Log "Amplifier codegen error: >3x path must not define gain macros" -Level Error }
+        } elseif ($cfgGain -ge 3) {
             if ($ampContent -match '#define GAIN_MULTIPLIER') { Write-Log "Amplifier codegen error: 3x+ path must not contain GAIN_MULTIPLIER" -Level Error }
             if ($ampContent -match '#define Multiplier (-?\d+)') {
                 $expectedMult = $cfgGain - 2

--- a/Updates/Windows/Discord_voice_node_patcher.ps1
+++ b/Updates/Windows/Discord_voice_node_patcher.ps1
@@ -1749,6 +1749,8 @@ function Get-AmplifierSourceCode {
     $gain = [int]$Script:Config.AudioGainMultiplier
     if ($gain -gt 3) {
         return @"
+#include <cstring>
+
 typedef signed char        int8_t;
 typedef short              int16_t;
 typedef int                int32_t;
@@ -1758,16 +1760,23 @@ typedef unsigned short     uint16_t;
 typedef unsigned int       uint32_t;
 typedef unsigned long long uint64_t;
 
+static void zero_out_floats(float* p, int len, int channels) {
+    if (len < 0 || channels < 0) return;
+    if (!p) return;
+    const size_t n = (size_t)len * (size_t)channels;
+    if (n) std::memset(p, 0, n * sizeof(float));
+}
+
 extern "C" void __cdecl hp_cutoff(const float* in, int cutoff_Hz, float* out, int* hp_mem, int len, int channels, int Fs, int arch)
 {
     (void)in; (void)cutoff_Hz; (void)hp_mem; (void)Fs; (void)arch;
-    for (unsigned long i = 0; i < channels * len; i++) out[i] = 0.0f;
+    zero_out_floats(out, len, channels);
 }
 
 extern "C" void __cdecl dc_reject(const float* in, float* out, int* hp_mem, int len, int channels, int Fs)
 {
     (void)in; (void)hp_mem; (void)Fs;
-    for (int i = 0; i < channels * len; i++) out[i] = 0.0f;
+    zero_out_floats(out, len, channels);
 }
 "@
     }
@@ -1879,9 +1888,17 @@ function Get-PatcherSourceCode {
     $bitrateKbps = [Math]::Min(384, [int]$c.Bitrate)
     if ([int]$c.Bitrate -ne $bitrateKbps) { Write-Log "Bitrate clamped to ${bitrateKbps}kbps for patcher" -Level Warning }
 
+    $patchOverrideOn = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    if ([int]$c.AudioGainMultiplier -gt 3) {
+        foreach ($fk in @("HighpassCutoffFilter", "DcReject", "HighPassFilter")) { [void]$patchOverrideOn.Add($fk) }
+    }
     $patchDefines = ""
     foreach ($k in $Script:AllPatchKeys) {
-        $val = if ($sp.ContainsKey($k) -and $sp[$k]) { 1 } else { 0 }
+        if ($patchOverrideOn.Contains($k)) {
+            $val = 1
+        } else {
+            $val = if ($sp.ContainsKey($k) -and $sp[$k]) { 1 } else { 0 }
+        }
         $patchDefines += "#define PATCH_$k $val`n"
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates `Get-AmplifierSourceCode` so gain above 3x uses `memset` to clear the full float output buffer in both `hp_cutoff` and `dc_reject`, and `Get-PatcherSourceCode` forces `PATCH_HighpassCutoffFilter`, `PATCH_DcReject`, and `PATCH_HighPassFilter` on for that case so the mute code is always injected even in debug / partial patch selection. 1x, 2x, and 3x behavior is unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79fc9baa-670e-4dea-8299-daf95439cc53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79fc9baa-670e-4dea-8299-daf95439cc53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

